### PR TITLE
GQL /scene/... could only query objects in the active scene

### DIFF
--- a/Assets/Unium/Unium.cs
+++ b/Assets/Unium/Unium.cs
@@ -2,7 +2,8 @@
 
 using UnityEngine;
 using System;
-
+using System.Collections.Generic;
+using System.Linq;
 using gw.gql;
 using gw.proto.utils;
 
@@ -107,7 +108,21 @@ namespace gw.unium
             Interpreters.Add( typeof( GameObject[] ),   new InterpreterGameObjectArray() );
             Interpreters.Add( typeof( Root ),           new InterpreterSearchRoot() );
 
-            Func<object> scene = () => UnityEngine.SceneManagement.SceneManager.GetActiveScene().GetRootGameObjects();
+            // /scene GQL root queries all root-level gameobjects across scenes 
+            
+            // Note: Elegant method uses deprecated method
+            Func<object> scene = () => UnityEngine.SceneManagement.SceneManager.GetAllScenes().SelectMany(s => s.GetRootGameObjects());
+
+            // Note: Alternate method without warnings
+            // Func<object> scene = () =>
+            // {
+            //     var allGameObjects = new List<GameObject>();
+            //     for (int i = 0; i < UnityEngine.SceneManagement.SceneManager.sceneCount; i++)
+            //     {
+            //         allGameObjects.AddRange(UnityEngine.SceneManagement.SceneManager.GetSceneAt(i).GetRootGameObjects());
+            //     }
+            //     return allGameObjects;
+            // };
 
             Root.Add( "scene",  scene );
             Root.Add( "stats",  Stats.Singleton );

--- a/Assets/Unium/Unium.cs
+++ b/Assets/Unium/Unium.cs
@@ -111,7 +111,11 @@ namespace gw.unium
             // /scene GQL root queries all root-level gameobjects across scenes 
             
             // Note: Elegant method uses deprecated method
-            Func<object> scene = () => UnityEngine.SceneManagement.SceneManager.GetAllScenes().SelectMany(s => s.GetRootGameObjects());
+            Func<object> scene = () =>
+                UnityEngine.SceneManagement.SceneManager
+                    .GetAllScenes()
+                    .SelectMany(s => s.GetRootGameObjects())
+                    .ToArray();
 
             // Note: Alternate method without warnings
             // Func<object> scene = () =>
@@ -119,9 +123,10 @@ namespace gw.unium
             //     var allGameObjects = new List<GameObject>();
             //     for (int i = 0; i < UnityEngine.SceneManagement.SceneManager.sceneCount; i++)
             //     {
-            //         allGameObjects.AddRange(UnityEngine.SceneManagement.SceneManager.GetSceneAt(i).GetRootGameObjects());
+            //         allGameObjects.AddRange(UnityEngine.SceneManagement.SceneManager.GetSceneAt(i)
+            //             .GetRootGameObjects());
             //     }
-            //     return allGameObjects;
+            //     return allGameObjects.ToArray();
             // };
 
             Root.Add( "scene",  scene );


### PR DESCRIPTION
However many projects utilize multi-scene loading. This was preventing me from taking advantage of GQL. The fix is simple, unfortunately the elegant one-liner uses a deprecated method 😉 so I've provided two options.

Please consider integrating this into Unium! It's an important feature.