### PR TITLE
Serialize sub types of types with custom converters

### DIFF
--- a/Assets/Editor/Unit Tests/TestReflection.cs
+++ b/Assets/Editor/Unit Tests/TestReflection.cs
@@ -69,6 +69,34 @@ public class TestReflection
 
         Assert.AreEqual( @"{""{ x = 1 }"":1,""{ z = 1 }"":2,""{ fish = 1, z = 2 }"":3}", JsonReflector.Reflect( nonStringKeys ) );
     }
+
+
+    class A
+    {
+
+    }
+
+    class B : A
+    {
+
+    }
+
+    public class SerialiseType : JsonSerialiser
+    {
+        override public string Convert( object o )
+        {
+            return o.GetType().ToString();
+        }
+    }
+
+    [Test]
+    public void Converters()
+    {
+        JsonSerialiser aSerializer = new SerialiseType();
+        JsonReflector.Add(typeof(A), aSerializer);
+        Assert.AreEqual( @"TestReflection+A", JsonReflector.Reflect( new A() ));
+        Assert.AreEqual( @"TestReflection+B", JsonReflector.Reflect( new B() ));
+    }
 }
 
 

--- a/Assets/Unium/Core/gw.proto.utils/JsonSerialiser.cs
+++ b/Assets/Unium/Core/gw.proto.utils/JsonSerialiser.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace gw.proto.utils
 {
@@ -65,16 +66,23 @@ namespace gw.proto.utils
 
         public bool HasOverride( Type type )
         {
-            return mConverters.ContainsKey( type );
+            return FindFirstConverter (type) != null;
+        }
+
+        // note doesn't take into account if there's a better converter down the class hierarchy
+        private JsonSerialiser FindFirstConverter(Type type) {
+            Type t = mConverters.Keys.FirstOrDefault (item => item.IsAssignableFrom (type));
+            return t != null ? mConverters [t] : null;
         }
 
         public string Serialise( object o )
         {
             var type = o.GetType();
 
-            if( mConverters.ContainsKey( type ) )
+            JsonSerialiser serializer = FindFirstConverter (type);
+            if( serializer != null )
             {
-                return mConverters[ type ].Convert( o );
+                return serializer.Convert( o );
             }
 
             return SerialiseValueType( o );


### PR DESCRIPTION
Even though Unium has a special converter for `Transform`, `RectTransform` weren't converted using the parent class converter.