### PR TITLE
Modify WebSocket.cs variable

### DIFF
--- a/Assets/Unium/Core/gw.proto.http/WebSocket.cs
+++ b/Assets/Unium/Core/gw.proto.http/WebSocket.cs
@@ -355,7 +355,7 @@ namespace gw.proto.http
                     buffer[ 0 ] = code;
                     buffer[ 1 ] = (byte) numBytes;
                 }
-                else if( totalBytes < 65536 )
+                else if( numBytes < 65536 )
                 {
                     headerSize = 4;
 


### PR DESCRIPTION
When create a frame, write a header in the size of the frame. not total message size.