### PR TITLE
update to allow parenthesis in object name

### DIFF
--- a/Assets/Unium/GQL/Query/Path.cs
+++ b/Assets/Unium/GQL/Query/Path.cs
@@ -50,7 +50,7 @@ namespace gw.gql
         static Regex sMatchToken = new Regex(
 
             @"(?<type>[/\.])" +
-            @"(?<name>[^\[\]\./=\(]+)?" +
+            @"(?<name>(?(?<=\/)[^\[\]\.\/]+|[^\[\]\.\/=\(]+))?" +
             @"(\[(?<where>[^\]]+)\])?" +
             @"(?<action>(=|\()(?<params>.*))?"
             , RegexOptions.Singleline
@@ -126,13 +126,6 @@ namespace gw.gql
 
                 if( match.Groups[ "action" ].Success )
                 {
-                    // actions can only be applied to attributes
-
-                    if( type != Segment.Type.Attribute )
-                    {
-                        throw new FormatException( "GQL::Query - failed to parse query, no attribute to set" );
-                    }
-
                     // get target (attribute) of action
 
                     Target = name;


### PR DESCRIPTION
the condition in the action check was removed because it wasn't getting
triggered anymore. furthermore, it was simple enough to allow equals
sign in the name too.

resolves #62 