### PR TITLE
Query Parameter Support for Websocket Requests

### DIFF
--- a/Assets/Unium/Core/UniumSocket.cs
+++ b/Assets/Unium/Core/UniumSocket.cs
@@ -157,7 +157,7 @@ namespace gw.unium
 
                 // find route
 
-                var route = Unium.RoutesSocket.Find( msg.q );
+                var route = Unium.RoutesSocket.Find( msg.uri );
 
                 if( route == null || route.Handler == null )
                 {

--- a/Assets/Unium/Core/UniumSocketMessage.cs
+++ b/Assets/Unium/Core/UniumSocketMessage.cs
@@ -24,7 +24,10 @@ namespace gw.unium
             }
 
             public string   id;             // arbitary message identifier
-            public string   q;              // query
+            public string   q;              // full query (uri + optional query string parameters)
+            private int     queryStringIndex           { get { return q.IndexOf('?'); } }
+            public string   uri                        { get { return queryStringIndex >= 0 ? q.Substring(0, queryStringIndex) : q; } }
+            public string   queryParameters            { get { return queryStringIndex >= 0 ? q.Substring(queryStringIndex + 1) : string.Empty; } }
             public Repeat   repeat;
 
 

--- a/Assets/Unium/Routing/RouterAdapters.cs
+++ b/Assets/Unium/Routing/RouterAdapters.cs
@@ -74,7 +74,8 @@ namespace gw.unium
         public bool                 Rejected                    { get; private set; }
 
 
-        public override String Path                             { get { return mMessage.q; } }
+        public override String Path                             { get { return mMessage.uri; } }
+        public override string Query                            { get { return mMessage.queryParameters; } }
         public override byte[] Body                             { get { return null; } }
 
         public override void SetContentType( string mimetype )  {}


### PR DESCRIPTION
This adds support for query string parameters with websocket requests by splitting out and exposing the "q" query into its URI and QueryParameters components (while leaving the existing full "q" value available).

Previously only HTTP requests supported query string parameters. This brings them one small step closer to feature parity.