### PR TITLE
Update to 2020.1+

### DIFF
--- a/Routing/HandlerFile.cs
+++ b/Routing/HandlerFile.cs
@@ -100,7 +100,11 @@ namespace gw.unium
                 Thread.Sleep( 10 );
             }
 
+#if UNITY_2020_1_OR_NEWER
+            if( www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError )
+#else
             if( www.isNetworkError || www.isHttpError )
+#endif
             {
                 req.Reject( ResponseCode.InternalServerError );
             }


### PR DESCRIPTION
This just fixes a deprecation warning introduced in 2020.2, but the code that replaced the deprecated code was introduced in 2020.1.

https://github.com/Unity-Technologies/UnityCsReference/blame/master/Modules/UnityWebRequest/Public/UnityWebRequest.bindings.cs